### PR TITLE
Soften color of invisible characters

### DIFF
--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -12,7 +12,7 @@
 // Guide colors
 @syntax-wrap-guide-color: @dark-gray;
 @syntax-indent-guide-color: @gray;
-@syntax-invisible-character-color: @gray;
+@syntax-invisible-character-color: lighten(@dark-purple, 15%);
 
 // For find and replace markers
 @syntax-result-marker-color: @light-gray;


### PR DESCRIPTION
Following your reasoning on minimizing the visual impact of less useful elements, I tried to express the color of invisible characters as a lighter version of the background color that ends up blending more with it.

![invisible-character-color](https://cloud.githubusercontent.com/assets/3891/21498575/09ae016e-cc2e-11e6-91f9-b10ac2c90ab5.gif)
